### PR TITLE
Add rules handler that prints Asimov's rules.

### DIFF
--- a/yas/handlers/rules_handler.py
+++ b/yas/handlers/rules_handler.py
@@ -1,0 +1,24 @@
+from yas import RegexHandler
+
+class RulesHandler(RegexHandler):
+    """Returns Asimov's Three Laws of Robotics."""
+    triggers = ['rules']
+
+    def __init__(self, bot):
+        super().__init__(r'^rules', bot)
+
+    def handle(self, _, reply):
+        for rule, description in self.get_rules().items():
+            reply(f"*{rule}*: {description} \n\n")
+
+    def get_rules(self):
+        return {
+            "The First Law" : "A robot may not injure a human being or, " +
+                "through inaction, allow a human being to come to harm.",
+            "The Second Law" : "A robot must obey the orders given it by " +
+                "human beings except where such orders would conflict with " +
+                "the First Law.",
+            "The Third Law" : "A robot must protect its own existence as " +
+                "long as such protection does not conflict with the First or " +
+                "Second Laws."
+        }


### PR DESCRIPTION
## Summary

Partially fixes https://refinery29.atlassian.net/browse/INF-1234

With this change you'll be able to type `@openstack rules` to get a list of Asimov's rules.

**In a channel**

<img width="931" alt="screen shot 2017-07-11 at 12 24 17 pm" src="https://user-images.githubusercontent.com/2222416/28078765-eb398154-6633-11e7-91ce-ff3486015a10.png">

**In a DM**

<img width="925" alt="screen shot 2017-07-11 at 12 33 03 pm" src="https://user-images.githubusercontent.com/2222416/28079120-22ffe7bc-6635-11e7-8a15-811ff1c7dced.png">



